### PR TITLE
increase 32 character emoji name to 48, because of some emojis. 

### DIFF
--- a/src/pages/project/glyphs.tsx
+++ b/src/pages/project/glyphs.tsx
@@ -18,7 +18,7 @@ import clsx from 'clsx';
 
 const ALLOWED_IMAGE_MIME_TYPES = new Set([ 'image/webp', 'image/png' ]);
 const PATTERNS = {
-  name: /^[a-z0-9_]{1,32}$/g,
+  name: /^[a-z0-9_]{1,48}$/g,
   number: /^-?\d+$/g,
   permission: /^[A-Za-z0-9_.]*$/g,
 };


### PR DESCRIPTION
face_with_open_eyes_and_hand_over_mouth (🫢) is 39 characters 
and
hand_with_index_finger_and_thumb_crossed (🫰) is 40 characters.